### PR TITLE
Missing build-base dependency in Builder Dockerfile

### DIFF
--- a/cnb-components/builders/juvo-builder/Dockerfile
+++ b/cnb-components/builders/juvo-builder/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.12-alpine3.21 AS base
+FROM python:3.12.8-slim-bookworm AS base
 
 # Each stack needs an identifier. This is used by the CNB framework to
 # determine compatibility among components, for example, matching the build
 # and run images of a stack, or stack eligibility to use with a particular buildpack.
-ENV CNB_STACK_ID="com.jurisfutura.cnb.stacks.alpine"
-LABEL io.buildpacks.stack.id="com.jurisfutura.cnb.stacks.alpine"
+ENV CNB_STACK_ID="com.jurisfutura.cnb.stacks.debian"
+LABEL io.buildpacks.stack.id="com.jurisfutura.cnb.stacks.debian"
 
 # The CNB framework executes commands during image building as a specified
 # user rather than the Docker default of root. In fact, it is expressly
@@ -13,22 +13,27 @@ LABEL io.buildpacks.stack.id="com.jurisfutura.cnb.stacks.alpine"
 ENV CNB_USER_ID=1000
 ENV CNB_GROUP_ID=1000
 ENV CNB_PLATFORM_API=0.11
-RUN addgroup -g ${CNB_GROUP_ID} cnb
-RUN adduser -u ${CNB_USER_ID} -G cnb cnb -D
 
-# alpine-sdk replaces build-essential
+RUN groupadd cnb --gid ${CNB_GROUP_ID}
+RUN useradd --uid ${CNB_USER_ID} --gid ${CNB_GROUP_ID} -m -s /bin/bash cnb
 
-RUN apk add --update --no-cache ca-certificates alpine-sdk python3-dev \
-                     ncurses gdbm-dev libc6-compat libzmq \
-                     zlib-dev libssl3 openssl libffi-dev openssh bash
-RUN apk add --no-cache build-base python3-dev py3-pip
+RUN apt-get update && \
+    apt-get install -y ca-certificates build-essential python3-dev && \
+    apt-get install -y libncursesw5-dev libgdbm-dev libc6-dev && \
+    apt-get install -y libzmq3-dev && \
+    apt-get install -y zlib1g-dev libssl-dev openssl libffi-dev && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip --no-cache-dir install "poetry==1.8.4"
 
 # BUILD IMAGE
 
 FROM base AS build
 
-RUN apk add --update git
+RUN apt-get update && \
+    apt-get install -y git && \
+    rm -rf /var/lib/apt/lists/*
+
 LABEL io.buildpacks.stack.mixins="[\"build:git\"]"
 
 # we set the active user for the image employing the environment variables

--- a/cnb-components/builders/juvo-builder/Dockerfile
+++ b/cnb-components/builders/juvo-builder/Dockerfile
@@ -21,8 +21,8 @@ RUN adduser -u ${CNB_USER_ID} -G cnb cnb -D
 RUN apk add --update --no-cache ca-certificates alpine-sdk python3-dev \
                      ncurses gdbm-dev libc6-compat libzmq \
                      zlib-dev libssl3 openssl libffi-dev openssh bash
-
-RUN pip --no-cache-dir install 'poetry==1.8.4'
+RUN apk add --no-cache build-base python3-dev py3-pip
+RUN pip --no-cache-dir install "poetry==1.8.4"
 
 # BUILD IMAGE
 


### PR DESCRIPTION
There was an error when running in the image About missing pydantic_core

```
File "/workspace/.venv/lib/python3.12/site-packages/pydantic/__init__.py", line 421, in __getattr__
    module = import_module(module_name, package=package)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/.venv/lib/python3.12/site-packages/pydantic/main.py", line 29, in <module>
    import pydantic_core
  File "/workspace/.venv/lib/python3.12/site-packages/pydantic_core/__init__.py", line 6, in <module>
    from ._pydantic_core import (
ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
```

In Alpine, we need `build-base` to compile certain C extensions. It seems that pydantic-core is one of them
